### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,12 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :correct_user, only: [:edit, :update]
 
-  # before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]
-  # before_action :set_item, only: [:show, :edit, :update, :destroy]
-  # before_action :correct_user, only: [:edit, :update, :destroy]
-  #削除機能実装用
+  before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   def new
     @item = Item.new
@@ -28,12 +24,11 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def destroy
-  #   @item = Item.find(params[:id])
-  #   @item.destroy
-  #   redirect_to root_path
-  # end
-  #削除機能実装用
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to root_path
+  end
 
   def show
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,4 @@
 class ItemsController < ApplicationController
-
   before_action :authenticate_user!, only: [:new, :edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :correct_user, only: [:edit, :update, :destroy]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
     @item.destroy
     redirect_to root_path
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,8 +34,7 @@
 
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%#= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" #削除機能実装用%>  
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>  
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>  
 
 <%#購入機能実装後に記述  elsif user_signed_in? && current_user != @item.user && !@item.sold_out? %>
 <% elsif user_signed_in? && current_user != @item.user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,7 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   root to: 'items#index'
-  resources :items, only: [:new, :index, :create, :show, :edit, :update] 
-  # resources :items, only: [:new, :index, :create, :show, :edit, :update, :destroy] #削除機能実装用
+  resources :items, only: [:new, :index, :create, :show, :edit, :update, :destroy] 
   end
 
 


### PR DESCRIPTION
#What
商品削除機能

#Why
フリマアプリで出品した商品を削除する機能を実装するため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/db7a4e1c0da9247af04c7079d3f09338